### PR TITLE
7 user story 12

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -45,7 +45,7 @@ class Merchants::ItemsController < ApplicationController
   end
 
   private
-
+  #TODO: not all calls to merchant_item_params have (:item)
   def merchant_item_params
     params.require(:item).permit(:name, :description, :unit_price, :status)
   end

--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -1,6 +1,7 @@
 class Merchants::ItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
+    # @top_items = @merchant.top_items
     @items = @merchant.items
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,6 +7,8 @@ class Invoice < ApplicationRecord
 
   enum status: ['in progress', 'completed', 'cancelled']
 
+  scope :has_successful_transaction, -> { joins(:transactions).where(transactions: {result: 'success'})}
+
   def total_revenue
     self.invoice_items.sum('quantity*unit_price')
   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -12,6 +12,10 @@ class Merchant < ApplicationRecord
   def top_customers
   end
 
+  def top_items
+    self.items.joins(:invoices).merge(Invoice.has_successful_transaction).select('items.*, sum(invoice_items.quantity * invoice_items.unit_price) as revenue').group('items.name', :id).order(revenue: :desc).limit(5)
+  end
+
   def self.enabled_merchants
     self.where(status: 'enabled')
   end

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,3 +1,11 @@
+<h2>Top Items</h2>
+<div id="top_items">
+  <% @merchant.top_items.each_with_index do |item, index| %>
+    <%= "#{index + 1}. " %> <%= link_to "#{item.name}", merchant_item_path(@merchant, item)%>
+    <%= "Total Revenue: #{item.revenue}" %>
+    <br>
+  <% end %>
+</div>
 <section id="enabled_items">
 <h2>Enabled Items</h2>
   <% @items.enabled.each do |item| %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 8) do
 
   # These are extensions that must be enabled in order to support this database

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -6,4 +6,5 @@ FactoryBot.define do
     status { 0 }
     association :invoice
   end
+  
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -35,5 +35,11 @@ FactoryBot.define do
         create(:successful_transaction, invoice: invoice)
       end
     end
+
+    factory :invoice_with_unsuccessful_transaction do
+      after(:create) do |invoice, options|
+        create(:transaction, invoice: invoice)
+      end
+    end
   end
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -29,5 +29,11 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :invoice_with_successful_transaction do
+      after(:create) do |invoice, options|
+        create(:successful_transaction, invoice: invoice)
+      end
+    end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -34,5 +34,18 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :item_with_unsuccessful_transaction do
+      transient do
+        number_of_invoices { 2 }
+      end
+
+      after(:create) do |item, options|
+        invoices = create_list(:invoice_with_unsuccessful_transaction, options.number_of_invoices)   
+        invoices.each do |invoice|
+          create(:invoice_item, quantity: 5, unit_price: 10000, invoice: invoice, item: item)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -19,5 +19,20 @@ FactoryBot.define do
         create(:invoice_item, invoice: evaluator.invoice, item: item)
       end
     end
+
+    #TODO: consider adding price / qty if you want to do more granular testing
+    #number is sufficient because just give an item more sales
+    factory :item_with_successful_transaction do
+      transient do
+        number_of_invoices { 2 }
+      end
+
+      after(:create) do |item, options|
+        invoices = create_list(:invoice_with_successful_transaction, options.number_of_invoices)   
+        invoices.each do |invoice|
+          create(:invoice_item, quantity: 5, unit_price: 10000, invoice: invoice, item: item)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     #TODO: consider adding price / qty if you want to do more granular testing
-    #number is sufficient because just give an item more sales
+    #number_of_invoices is sufficient because it gives an item more sales instead of modifying price
     factory :item_with_successful_transaction do
       transient do
         number_of_invoices { 2 }

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -104,22 +104,39 @@ RSpec.describe 'The merchant items index page', type: :feature do
 
     describe 'Popular Items' do
       it 'displays the name of the top 5 items with links to the item show page' do
+
+        item_1 = create(:item_with_successful_transaction, number_of_invoices: 5, merchant: merchant_1)
+        item_2 = create(:item_with_successful_transaction, number_of_invoices: 1, merchant: merchant_1)
+        item_3 = create(:item_with_successful_transaction, number_of_invoices: 3, merchant: merchant_1)
+        item_4 = create(:item_with_successful_transaction, number_of_invoices: 6, merchant: merchant_1)
+        item_5 = create(:item_with_successful_transaction, number_of_invoices: 2, merchant: merchant_1)
+        item_6 = create(:item_with_successful_transaction, number_of_invoices: 4, merchant: merchant_1)
+
         visit merchant_items_path(merchant_1)
 
-        save_and_open_page
         within("#top_items") do
-          expect(page).to have_content "1. ??"
-          expect(page).to have_link "Update link info"
-          expect(page).to have_content "5. ???"
-          expect(page).to have_link "Update link info"
+          expect(page).to have_content "1. #{item_4.name}"
+          expect(page).to have_link "#{item_4.name}"
+          expect(page).to have_content "5. #{item_5.name}"
+          expect(page).to have_link "#{item_5.name}"
         end
       end
 
       it 'displays the total revenue generated for each item in order from most to least' do
+
+        item_1 = create(:item_with_successful_transaction, number_of_invoices: 5, merchant: merchant_1)
+        item_2 = create(:item_with_successful_transaction, number_of_invoices: 1, merchant: merchant_1)
+        item_3 = create(:item_with_successful_transaction, number_of_invoices: 3, merchant: merchant_1)
+        item_4 = create(:item_with_successful_transaction, number_of_invoices: 6, merchant: merchant_1)
+        item_5 = create(:item_with_successful_transaction, number_of_invoices: 2, merchant: merchant_1)
+        item_6 = create(:item_with_successful_transaction, number_of_invoices: 4, merchant: merchant_1)
+
         visit merchant_items_path(merchant_1)
-        
-        expect("1. ?? Revenue 123").to appear_before "3. ?? 123"
-        expect("3. ?? 123").to appear_before "5. ?? Revenue: 123123"
+        #TODO:orderly didn't like/couldn't find expectations with names.
+        within("#top_items") do
+          expect("Total Revenue: 300000").to appear_before "Total Revenue: 200000"
+          expect("Total Revenue: 200000").to appear_before "Total Revenue: 100000"
+        end
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -130,6 +130,8 @@ RSpec.describe 'The merchant items index page', type: :feature do
         item_4 = create(:item_with_successful_transaction, number_of_invoices: 6, merchant: merchant_1)
         item_5 = create(:item_with_successful_transaction, number_of_invoices: 2, merchant: merchant_1)
         item_6 = create(:item_with_successful_transaction, number_of_invoices: 4, merchant: merchant_1)
+        item_7 = create(:item_with_unsuccessful_transaction, number_of_invoices: 11, merchant: merchant_1)
+        item_8 = create(:item_with_successful_transaction, number_of_invoices: 4, merchant: merchant_2)
 
         visit merchant_items_path(merchant_1)
         #TODO:orderly didn't like/couldn't find expectations with names.

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -101,5 +101,26 @@ RSpec.describe 'The merchant items index page', type: :feature do
         expect(current_path).to eq new_merchant_item_path(merchant_1)
       end
     end
+
+    describe 'Popular Items' do
+      it 'displays the name of the top 5 items with links to the item show page' do
+        visit merchant_items_path(merchant_1)
+
+        save_and_open_page
+        within("#top_items") do
+          expect(page).to have_content "1. ??"
+          expect(page).to have_link "Update link info"
+          expect(page).to have_content "5. ???"
+          expect(page).to have_link "Update link info"
+        end
+      end
+
+      it 'displays the total revenue generated for each item in order from most to least' do
+        visit merchant_items_path(merchant_1)
+        
+        expect("1. ?? Revenue 123").to appear_before "3. ?? 123"
+        expect("3. ?? 123").to appear_before "5. ?? Revenue: 123123"
+      end
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -30,11 +30,18 @@ RSpec.describe Merchant, type: :model do
 
   describe 'top_items' do
     it 'returns the top 5 items and their total revenue in ascending order by revenue for a merchant' do
-      create(:item_with_successful_transaction, merchant: merchant_2)
-
-      expect(merchant_2.top_items).to eq [item]
-      expect(item_1.revenue).to eq 
-      expect(item_4.revenue).to eq  
+      #factorybot revenue per invoice is 50000
+      item_1 = create(:item_with_successful_transaction, number_of_invoices: 5, merchant: merchant_2)
+      item_2 = create(:item_with_successful_transaction, number_of_invoices: 1, merchant: merchant_2)
+      item_3 = create(:item_with_successful_transaction, number_of_invoices: 3, merchant: merchant_2)
+      item_4 = create(:item_with_successful_transaction, number_of_invoices: 6, merchant: merchant_2)
+      item_5 = create(:item_with_successful_transaction, number_of_invoices: 2, merchant: merchant_2)
+      item_6 = create(:item_with_successful_transaction, number_of_invoices: 4, merchant: merchant_2)
+      item_7 = create(:item_with_successful_transaction, merchant: merchant_3)
+      
+      expect(merchant_2.top_items).to eq [item_4, item_1, item_6, item_3, item_5]
+      expect(merchant_2.top_items[0].revenue).to eq 300000 
+      expect(merchant_2.top_items[4].revenue).to eq 100000
     end
   end
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -37,8 +37,9 @@ RSpec.describe Merchant, type: :model do
       item_4 = create(:item_with_successful_transaction, number_of_invoices: 6, merchant: merchant_2)
       item_5 = create(:item_with_successful_transaction, number_of_invoices: 2, merchant: merchant_2)
       item_6 = create(:item_with_successful_transaction, number_of_invoices: 4, merchant: merchant_2)
-      item_7 = create(:item_with_successful_transaction, merchant: merchant_3)
-      
+      item_7 = create(:item_with_successful_transaction, number_of_invoices: 11, merchant: merchant_3)
+
+      #TODO: Add unsuccessful transactions
       expect(merchant_2.top_items).to eq [item_4, item_1, item_6, item_3, item_5]
       expect(merchant_2.top_items[0].revenue).to eq 300000 
       expect(merchant_2.top_items[4].revenue).to eq 100000

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Merchant, type: :model do
     end
   end
 
+  describe 'top_items' do
+    it 'returns the top 5 items and their total revenue in ascending order by revenue for a merchant' do
+      create(:item_with_successful_transaction, merchant: merchant_2)
+
+      expect(merchant_2.top_items).to eq [item]
+      expect(item_1.revenue).to eq 
+      expect(item_4.revenue).to eq  
+    end
+  end
+
   describe 'disabled status' do
     it 'can set the merchant status to disabled' do
       expect(merchant_1.status).to eq("disabled")


### PR DESCRIPTION
#7 Add top_items method to merchant model. Add display for top_items to merchant index page. Had some difficulties with the orderly gem, couldn't expect the names to appear before/after so I just tested the order of the revenue. Left a TODO tag where the problem is located. 