### PR TITLE
Fix/GitHub

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,9 @@
 class ApplicationController < ActionController::Base
-  before_action :github
   helper_method :admin
     
   def github
-    @github = GithubRepo.new
   end
+
 
   def admin
     false

--- a/app/controllers/merchants/invoices_controller.rb
+++ b/app/controllers/merchants/invoices_controller.rb
@@ -1,8 +1,11 @@
 class Merchants::InvoicesController < ApplicationController
 
+  before_action :github, only: [:index]
+
   def index
     merchant
     @invoices = @merchant.invoices
+    @github = GithubRepo.new
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,31 @@
 module ApplicationHelper
+  class GithubDecorator
+    def initialize(githubrepo)
+      @git = githubrepo
+    end
+
+    def usernames
+      @git.usernames.join(', ')
+    end
+
+    def commits
+      hash_to_display(@git.collab_commits)
+    end
+
+    def pull_requests
+      hash_to_display(@git.pull_requests)
+    end
+
+    def repo_name
+      @git.repo_name
+    end
+
+    private
+
+    def hash_to_display(hash)
+      hash.map do |key, value|
+        "#{key}: #{value}"
+      end.join(', ')
+    end
+  end
 end

--- a/app/views/merchants/invoices/index.html.erb
+++ b/app/views/merchants/invoices/index.html.erb
@@ -1,3 +1,5 @@
 <% @invoices.each do |invoice| %>
   <p>Invoice: <%= link_to "Invoice: #{invoice.id}", merchant_invoice_path(@merchant, invoice) %></p>
 <% end %>
+
+<%= render partial: 'shared/github_api' %>

--- a/app/views/shared/_github_api.html.erb
+++ b/app/views/shared/_github_api.html.erb
@@ -1,4 +1,5 @@
-<p>Repo Name: <%= @github.repo_name %></p>
-<p>User Names: </p>
-<p>Commits: </p>
-<p>Pull Requests: </p>
+<% github = ApplicationHelper::GithubDecorator.new(@github) %>
+<p>Repo Name: <%= github.repo_name %></p>
+<p>User Names: <%= github.usernames %></p>
+<p>Commits: <%= github.commits %></p>
+<p>Pull Requests: <%= github.pull_requests %> </p>

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe 'The merchant invoices index page', type: :feature do
       let(:merchant_1) { create(:merchant_with_invoices) }
       let(:merchant_2) { create(:merchant_with_invoices) }
 
+      describe 'github partial' do
+        it 'displays the repo info' do
+          visit merchant_invoices_path(merchant_1)
+
+          expect(page).to have_content "Repo Name: little-esty-shop"
+          expect(page).to have_content "User Names: Tscasady, pkseverance, Kerynn, pitzelalex"
+        end
+      end
+      
       it 'shows all of the invoices that include at least one of my merchant items and shows their id' do
         visit merchant_invoices_path(merchant_1)
 
@@ -24,6 +33,7 @@ RSpec.describe 'The merchant invoices index page', type: :feature do
         merchant_2.invoices.each do |invoice|
           expect(page).to have_content("Invoice: #{invoice.id}")
         end
+        save_and_open_page
       end
 
       it "has a link from each id to the corresponding merchant invoice page" do


### PR DESCRIPTION
Adds github partial to merchant invoices index page, an arbitrary page chosen to limit api calls. Tested for repo name and contributors with hardcoded expectations, the rest was excluded because I don't know how to stub an api call. Adds github decorator object to application helper to handle view logic of github repo data. 